### PR TITLE
chore: disable `golangci-lint` cache as it takes longer than actually…

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,6 +32,7 @@ jobs:
       uses: golangci/golangci-lint-action@v4
       with:
         version: v1.54
+        skip-cache: true
 
     - name: Vet
       run: go vet ./...


### PR DESCRIPTION
… it takes longer than actually running it