### PR TITLE
fix: `evmdebug.Debugger.Step()` blocks until opcode execution completes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ use_repo(
     "com_github_holiman_uint256",
     "com_github_rivo_tview",
     "com_github_spf13_cobra",
+    "org_golang_x_sync",
 )
 
 go_deps.module_override(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "934badda68f6775a528d875e579a163efbb5ffb0d9a57bd010d2d7383cfb5bdb",
+  "moduleFileHash": "2ebff2ab82e9f7187253731d3890a79a85b45c180a7e909b8fcc58bce9ba2dd7",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -67,7 +67,8 @@
             "com_github_google_go_cmp": "com_github_google_go_cmp",
             "com_github_holiman_uint256": "com_github_holiman_uint256",
             "com_github_rivo_tview": "com_github_rivo_tview",
-            "com_github_spf13_cobra": "com_github_spf13_cobra"
+            "com_github_spf13_cobra": "com_github_spf13_cobra",
+            "org_golang_x_sync": "org_golang_x_sync"
           },
           "devImports": [],
           "tags": [
@@ -94,7 +95,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 29,
+                "line": 30,
                 "column": 24
               }
             }
@@ -1767,7 +1768,7 @@
       "general": {
         "bzlTransitiveDigest": "zP01muRk4s4xWGK3gNPXOyDMQkOPsIhu99akeKWFFQ0=",
         "accumulatedFileDigests": {
-          "@@//:go.mod": "24d9fa82d505583d79f519591df0d1044ae8d673ddfe513d508c2590ce7e8b93",
+          "@@//:go.mod": "5ef993439dee7c479ae870e04f09e0fd8d7a0a607969a9e16e403b18b73aeff5",
           "@@rules_go~0.46.0//:go.sum": "d56fdb19b21a5f12bcf625c49432371ac39c2def0f564098fbda107f7c080f40",
           "@@//:go.sum": "3157b5026f950dcfde720d9f2bc5a2103e85df0733c220a25aa91f49d265a667",
           "@@gazelle~0.35.0//:go.mod": "48dc6e771c3028ee1c18b9ffc81e596fd5f6d7e0016c5ef280e30f2821f60473",
@@ -2436,6 +2437,7 @@
                 "com_github_holiman_uint256": "github.com/holiman/uint256",
                 "com_github_rivo_tview": "github.com/rivo/tview",
                 "com_github_spf13_cobra": "github.com/spf13/cobra",
+                "org_golang_x_sync": "golang.org/x/sync",
                 "com_github_bits_and_blooms_bitset": "github.com/bits-and-blooms/bitset",
                 "com_github_btcsuite_btcd_btcec_v2": "github.com/btcsuite/btcd/btcec/v2",
                 "com_github_consensys_bavard": "github.com/consensys/bavard",
@@ -2453,7 +2455,6 @@
                 "com_github_supranational_blst": "github.com/supranational/blst",
                 "org_golang_x_crypto": "golang.org/x/crypto",
                 "org_golang_x_exp": "golang.org/x/exp",
-                "org_golang_x_sync": "golang.org/x/sync",
                 "org_golang_x_sys": "golang.org/x/sys",
                 "org_golang_x_term": "golang.org/x/term",
                 "org_golang_x_text": "golang.org/x/text",
@@ -2539,7 +2540,8 @@
             "com_github_google_go_cmp",
             "com_github_holiman_uint256",
             "com_github_rivo_tview",
-            "com_github_spf13_cobra"
+            "com_github_spf13_cobra",
+            "org_golang_x_sync"
           ],
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO"

--- a/evmdebug/BUILD.bazel
+++ b/evmdebug/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "evmdebug",
@@ -9,8 +9,15 @@ go_library(
     importpath = "github.com/solidifylabs/specops/evmdebug",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/sync",
         "@com_github_ethereum_go_ethereum//core/vm",
         "@com_github_gdamore_tcell_v2//:tcell",
         "@com_github_rivo_tview//:tview",
     ],
+)
+
+go_test(
+    name = "evmdebug_test",
+    srcs = ["sync_test.go"],
+    deps = ["//:specops"],
 )

--- a/evmdebug/evmdebug.go
+++ b/evmdebug/evmdebug.go
@@ -88,6 +88,9 @@ func (d *Debugger) waitForEVMBlocked() {
 	// expecting users to pass a context to Wait().
 	//
 	// TODO: remove this once sync.Toggle has a non-context-aware option.
+
+	//lint:ignore errcheck Only sync.ErrToggleClosed is possible, which is a
+	// happy path for us.
 	d.d.blockingEVM.Wait(context.Background())
 }
 

--- a/evmdebug/evmdebug.go
+++ b/evmdebug/evmdebug.go
@@ -89,9 +89,9 @@ func (d *Debugger) waitForEVMBlocked() {
 	//
 	// TODO: remove this once sync.Toggle has a non-context-aware option.
 
-	//lint:ignore errcheck Only sync.ErrToggleClosed is possible, which is a
-	// happy path for us.
-	d.d.blockingEVM.Wait(context.Background())
+	// Deliberately dropping any error because only sync.ErrToggleClosed is
+	// possible, which is a happy path for us.
+	_ = d.d.blockingEVM.Wait(context.Background())
 }
 
 // close releases all resources; it MUST NOT be called before `done` is closed.

--- a/evmdebug/sync_test.go
+++ b/evmdebug/sync_test.go
@@ -1,0 +1,48 @@
+package evmdebug_test
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/solidifylabs/specops"
+)
+
+func TestStepSynchronisation(t *testing.T) {
+	var code Code
+	const n = 1_000
+	for i := 0; i < n; i++ {
+		// An operation that is likely to take longer than the return of
+		// dbg.Step() if no synchronisation is in place.
+		code = append(code, Fn(KECCAK256, PUSH0, PUSH(4096)))
+	}
+
+	// Synchronise the start of parallel tests to maximise load and increase
+	// probability of checking the stack before the KECCAK256 is finished (if
+	// debugger syncing is broken).
+	start := make(chan struct{})
+
+	for tt := 0; tt < runtime.GOMAXPROCS(0)*2; tt++ {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			<-start
+
+			dbg, _, err := code.StartDebugging(nil)
+			if err != nil {
+				t.Fatalf("%T.StartDebugging(nil) error %v", code, err)
+			}
+
+			state := dbg.State()
+			for i := 0; i < n; i++ {
+				dbg.Step()
+				dbg.Step()
+				dbg.Step()
+				if got, want := len(state.ScopeContext.Stack.Data()), i+1; got != want {
+					t.Fatalf("After %dº run of SHA3; got stack depth %d; want %d", i+1, got, want)
+				}
+			}
+		})
+	}
+
+	close(start)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/holiman/uint256 v1.2.4
 	github.com/rivo/tview v0.0.0-20240225120200-5605142ca62e
 	github.com/spf13/cobra v1.5.0
+	golang.org/x/sync v0.5.0
 )
 
 require (
@@ -29,7 +30,6 @@ require (
 	github.com/supranational/blst v0.3.11 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
-	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/term v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/internal/sync/BUILD.bazel
+++ b/internal/sync/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "sync",
+    srcs = [
+        "doc.go",
+        "toggle.go",
+    ],
+    importpath = "github.com/solidifylabs/specops/internal/sync",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "sync_test",
+    srcs = ["toggle_test.go"],
+    embed = [":sync"],
+    deps = ["@org_golang_x_sync//errgroup"],
+)

--- a/internal/sync/LICENSE
+++ b/internal/sync/LICENSE
@@ -1,0 +1,26 @@
+Copied from
+https://github.com/proofxyz/solgo/tree/2597ab7fa1be768a79df87e9b7638cd111fec0de/go/sync
+
+```
+MIT License
+
+Copyright (c) 2023 PROOF
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/internal/sync/README.md
+++ b/internal/sync/README.md
@@ -1,0 +1,6 @@
+Copied from
+https://github.com/proofxyz/solgo/tree/2597ab7fa1be768a79df87e9b7638cd111fec0de/go/sync
+under included MIT License.
+
+This package is in `/internal/` pending a more general home outside of this
+repo.

--- a/internal/sync/doc.go
+++ b/internal/sync/doc.go
@@ -1,0 +1,3 @@
+// Package sync provides synchronisation primitives not available in the
+// standard sync package.
+package sync

--- a/internal/sync/toggle.go
+++ b/internal/sync/toggle.go
@@ -1,0 +1,102 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// A Toggle allows for Wait()ing until a condition is true. Unlike a broadcast
+// mechanism that may be missed if waiting begins after a signal, waiting on an
+// already "on" Toggle returns immediately.
+//
+// The zero value for a Toggle is equivalent to Set(false). A Toggle MUST NOT be
+// copied as it contains a sync.Mutex.
+//
+// Toggle.Set(true) is a replacement for sync.Cond.Broadcast().
+//
+// The implementation uses a channel with a single-item buffer. When Set() to
+// true, the Toggle adds an item to the buffer, and when Set() to false, it
+// removes said item. All calls to Wait() receive on the channel to unblock,
+// and then immediately return the item. This allows for Context cancellation to
+// be honoured.
+type Toggle struct {
+	mu    sync.Mutex
+	state bool
+
+	// MUST NOT be accessed directly. Use sigChan() or
+	// sigChanWhenAlreadyLocked().
+	signal chan struct{}
+}
+
+// sigChan locks t and returns t.sigChanWhenAlreadyLocked().
+func (t *Toggle) sigChan() chan struct{} {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.sigChanWhenAlreadyLocked()
+}
+
+// sigChanWhenAlreadyLocked returns t.signal, make()ing it if nil.
+func (t *Toggle) sigChanWhenAlreadyLocked() chan struct{} {
+	if t.signal == nil {
+		t.signal = make(chan struct{}, 1)
+	}
+	return t.signal
+}
+
+// Close closes the Toggle. All Wait()ers, current and future, unblock and
+// return ErrToggleClosed.
+func (t *Toggle) Close() {
+	close(t.sigChan())
+}
+
+// ErrToggleClosed is returned by Toggle.Wait() if Toggle.Close() was called.
+var ErrToggleClosed = errors.New("toggle closed")
+
+// Wait blocks until the Toggle is Set() to true. If the last call to Set() was
+// Set(true) then Wait unblocks immediately.
+func (t *Toggle) Wait(ctx context.Context) error {
+	ch := t.sigChan()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+
+	case x, ok := <-ch:
+		if !ok {
+			return ErrToggleClosed
+		}
+
+		ch <- x
+		return nil
+	}
+}
+
+// Set sets the state of the Toggle. If the state is true, all current and
+// future calls to Wait() will unblock. Calls to Set are idempotent.
+//
+// Behaviour of Set() is undefined on a Close()d Toggle.
+func (t *Toggle) Set(state bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if state == t.state {
+		return
+	}
+	t.state = state
+
+	ch := t.sigChanWhenAlreadyLocked()
+	if state {
+		ch <- struct{}{}
+	} else {
+		<-ch
+	}
+}
+
+// State returns the last value sent to Set(), or false if Set() is yet to be
+// called.
+func (t *Toggle) State() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.state
+}

--- a/internal/sync/toggle_test.go
+++ b/internal/sync/toggle_test.go
@@ -1,0 +1,90 @@
+package sync
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestToggle(t *testing.T) {
+	ctx := context.Background()
+	tog := new(Toggle)
+
+	tog.Set(true)
+	t.Run("late Wait()", func(t *testing.T) {
+		// Wait()ing when the Toggle is "on" MUST NOT block, even if Wait() was
+		// called late.
+		if err := tog.Wait(ctx); err != nil {
+			t.Errorf("%T.Wait(ctx) error %v", tog, err)
+		}
+	})
+
+	t.Run("idempotent Set doesn't block", func(t *testing.T) {
+		for _, set := range []bool{true, false, true} {
+			for i := 0; i < 10; i++ {
+				tog.Set(set)
+			}
+		}
+	})
+
+	tog.Set(false)
+	// All Wait()ing go routines MUST only unblock when Set(true) is called, but
+	// no sooner.
+	group, gCtx := errgroup.WithContext(ctx)
+	unblocked := new(uint64)
+	for i := 0; i < 10; i++ {
+		group.Go(func() error {
+			if err := tog.Wait(gCtx); err != nil {
+				return err
+			}
+			atomic.AddUint64(unblocked, 1)
+			return nil
+		})
+	}
+
+	t.Run("blocks", func(t *testing.T) {
+		const timeout = 5 * time.Second
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		if got, want := tog.Wait(ctx), context.DeadlineExceeded; got != want {
+			t.Errorf("%T.Wait([ctx with deadline]) got %v; want %v", tog, got, want)
+		}
+		if n := atomic.LoadUint64(unblocked); n > 0 {
+			t.Fatalf("%d go routines unblocked", n)
+		}
+	})
+
+	t.Run("unblocks", func(t *testing.T) {
+		t.Parallel()
+		if err := group.Wait(); err != nil {
+			t.Errorf("%T.Wait(ctx) error %v", tog, err)
+		}
+		tog.Close()
+	})
+
+	t.Run("Set(true)", func(t *testing.T) {
+		t.Parallel()
+		tog.Set(true)
+	})
+}
+
+func TestToggleClose(t *testing.T) {
+	ctx := context.Background()
+	tog := new(Toggle)
+
+	t.Run("unblock", func(t *testing.T) {
+		t.Parallel()
+		if got, want := tog.Wait(ctx), ErrToggleClosed; got != want {
+			t.Errorf("%T.Wait() got %v; want %v", tog, got, want)
+		}
+	})
+
+	t.Run("Close()", func(t *testing.T) {
+		t.Parallel()
+		tog.Close()
+	})
+}


### PR DESCRIPTION
Fixes #25 

`Debugger.Wait()` is changed to block until execution is ready for _every_ opcode, not only the first. `Debugger.Step()` calls `Wait()` after each step because blocking on the _next_ opcode implies completion of the _last_ one.