### PR TITLE
feat: `Label` type to `PUSH` arbitrary locations by name

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "run.go",
         "specops.go",
         "stack.go",
+        "tags.go",
     ],
     importpath = "github.com/solidifylabs/specops",
     visibility = ["//visibility:public"],

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ New features will be prioritised based on demand. If there's something you'd lik
 - [x] `JUMPDEST` labels (absolute)
 - [ ] `JUMPDEST` labels (relative to `PC`)
 - [x] `PUSH(JUMPDEST)` by label with minimal bytes (1 or 2)
-- [x] Push multiple, concatenated `JUMPDEST` labels as one word
+- [x] `Label` tags; like `JUMPDEST` but don't add to code
+- [x] Push multiple, concatenated `JUMPDEST` / `Label` tags as one word
 - [x] Function-like syntax (i.e. Reverse Polish Notation is optional)
 - [x] Inverted `DUP`/`SWAP` special opcodes from "bottom" of stack (a.k.a. pseudo-variables)
 - [x] `PUSH<T>` for native Go types

--- a/examples_test.go
+++ b/examples_test.go
@@ -645,6 +645,24 @@ func ExamplePUSH_jumpTable() {
 	// Output: 0x6004356001603a8210695d58524c453e37302820601660068504011a573d3dfd5b64045461b590025b64020ea2db80025b63e11fed20025b6353971500025b63197b6830025b6305c6b740025b62cbf340025b620a26c0025b6102d0025b658886807a746e601a60068406011a565b60048203025b60038203025b60028203025b60018203025b025b3d52593df3
 }
 
+func ExampleLabel() {
+	const size = Inverted(DUP1)
+
+	dataTable := Code{
+		Fn(SUB, CODESIZE, PUSH("data")), // size
+
+		Fn(CODECOPY, PUSH0, PUSH("data"), size),
+		Fn(RETURN, PUSH0 /* size already on stack */),
+
+		Label("data"), // not compiled into anything
+		Raw{'h', 'e', 'l', 'l', 'o'},
+	}
+
+	fmt.Println(string(compileAndRun(dataTable, []byte{})))
+
+	// Output: hello
+}
+
 func compileAndRun[T interface{ []byte | [32]byte }](code Code, callData T) []byte {
 	var slice []byte
 	switch c := any(callData).(type) {

--- a/specops.go
+++ b/specops.go
@@ -13,7 +13,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/bits"
-	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -61,72 +60,6 @@ type Raw []byte
 func (r Raw) Bytecode() ([]byte, error) {
 	return []byte(r), nil
 }
-
-// A tag is a labelled location (byte index) in compiled code that can be
-// referenced by the label instead of the numeric value. For example, a
-// specops.JUMPDEST can be thought of as a tag followed by a
-// vm.OpCode(JUMPDEST). Similarly, a Label is a lone tag.
-type tag string
-
-type tagged interface {
-	types.Bytecoder
-	tag() tag
-}
-
-var _ = []tagged{JUMPDEST(""), Label("")}
-
-// A JUMPDEST is a Bytecoder that is converted into a vm.JUMPDEST while also
-// storing its location in the bytecode for use via
-// PUSH[string|JUMPDEST](<lbl>).
-type JUMPDEST string
-
-// Bytecode always returns an error as JUMPDEST values have special handling
-// inside Code.Compile().
-func (j JUMPDEST) Bytecode() ([]byte, error) {
-	return nil, fmt.Errorf("direct call to %T.Bytecode()", j)
-}
-
-func (j JUMPDEST) tag() tag {
-	return tag(j)
-}
-
-// A Label marks a specific point in the code without adding any bytes when
-// compiled. The corresponding numerical value is the first byte *after* the
-// Label.
-type Label string
-
-// Bytecode always returns an error as Label values have special handling
-// inside Code.Compile().
-func (l Label) Bytecode() ([]byte, error) {
-	return nil, fmt.Errorf("direct call to %T.Bytecode()", l)
-}
-
-func (l Label) tag() tag {
-	return tag(l)
-}
-
-// A pushTag pushes the tag's byte index to the stack.
-type pushTag tag
-
-func (p pushTag) Bytecode() ([]byte, error) {
-	return nil, fmt.Errorf("direct call to %T.Bytecode()", p)
-}
-
-// A pushTags is the multi-tag equivalent of pushTag. It can be used, for
-// example, for pushing jump tables.
-type pushTags []tag
-
-func (p pushTags) Bytecode() ([]byte, error) {
-	return nil, fmt.Errorf("direct call to %T.Bytecode()", p)
-}
-
-func asPushTags[T ~string](xs []T) pushTags {
-	return *(*pushTags)(unsafe.Pointer(&xs))
-}
-
-// Compile-time guarantee that tag itself has the same underlying type as those
-// accepted by the generic function.
-var _ = asPushTags[tag]
 
 // PUSHSelector returns a PUSH4 Bytecoder that pushes the selector of the
 // signature, i.e. `sha3(sig)[:4]`.

--- a/specops_test.go
+++ b/specops_test.go
@@ -269,8 +269,8 @@ func TestNoCallBytecode(t *testing.T) {
 	for _, b := range []types.Bytecoder{
 		Code{},
 		JUMPDEST(""),
-		pushLabel(""),
-		pushLabels{},
+		pushTag(""),
+		pushTags{},
 		stack.ExpectDepth(0),
 		stack.SetDepth(0),
 		Inverted(0),

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,70 @@
+package specops
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/solidifylabs/specops/types"
+)
+
+// A tag is a labelled location (byte index) in compiled code that can be
+// referenced by the label instead of the numeric value. For example, a
+// specops.JUMPDEST can be thought of as a tag followed by a
+// vm.OpCode(JUMPDEST). Similarly, a Label is a lone tag.
+type tag string
+
+type tagged interface {
+	types.Bytecoder
+	tag() tag
+}
+
+var _ = []tagged{JUMPDEST(""), Label("")}
+
+// A JUMPDEST is a Bytecoder that is converted into a vm.JUMPDEST while also
+// storing its location in the bytecode for use via
+// PUSH[string|JUMPDEST](<lbl>).
+type JUMPDEST string
+
+// Bytecode always returns an error as JUMPDEST values have special handling
+// inside Code.Compile().
+func (j JUMPDEST) Bytecode() ([]byte, error) {
+	return nil, fmt.Errorf("direct call to %T.Bytecode()", j)
+}
+
+func (j JUMPDEST) tag() tag { return tag(j) }
+
+// A Label marks a specific point in the code without adding any bytes when
+// compiled. The corresponding numerical value is the first byte *after* the
+// Label.
+type Label string
+
+// Bytecode always returns an error as Label values have special handling
+// inside Code.Compile().
+func (l Label) Bytecode() ([]byte, error) {
+	return nil, fmt.Errorf("direct call to %T.Bytecode()", l)
+}
+
+func (l Label) tag() tag { return tag(l) }
+
+// A pushTag pushes the tag's byte index to the stack.
+type pushTag tag
+
+func (p pushTag) Bytecode() ([]byte, error) {
+	return nil, fmt.Errorf("direct call to %T.Bytecode()", p)
+}
+
+// A pushTags is the multi-tag equivalent of pushTag. It can be used, for
+// example, for pushing jump tables.
+type pushTags []tag
+
+func (p pushTags) Bytecode() ([]byte, error) {
+	return nil, fmt.Errorf("direct call to %T.Bytecode()", p)
+}
+
+func asPushTags[T ~string](xs []T) pushTags {
+	return *(*pushTags)(unsafe.Pointer(&xs))
+}
+
+// Compile-time guarantee that tag itself has the same underlying type as those
+// accepted by the generic function.
+var _ = asPushTags[tag]


### PR DESCRIPTION
`Label`s act similarly to `specop.JUMPDEST` strings in that they can be pushed to the stack without knowing their actual location. Unlike a `JUMPDEST`, a `Label` doesn't add any bytecode when compiled.